### PR TITLE
Updated the sidebar footers to correct broken rss links for Venues & Tours

### DIFF
--- a/gigpress/templates/sidebar-list-footer.php
+++ b/gigpress/templates/sidebar-list-footer.php
@@ -29,11 +29,11 @@ if($show_feeds) : ?>
 	<?php endif; ?>	
 		
 	<?php if($tour) : ?>
-		<a href="<?php echo GIGPRESS_RSS; ?>&amp;tour=<?php echo $showdata['tour_id']; ?>" title="<?php echo $showdata['tour']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;tour=' . $showdata['tour_id']; ?>" title="<?php echo $showdata['tour']; ?> iCalendar" class="gigpress-ical">iCal</a>
+		<a href="<?php echo GIGPRESS_RSS; ?>&amp;tour=<?php echo $showdata['tour_id']; ?>" title="<?php echo $showdata['tour_plain']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;tour=' . $showdata['tour_id']; ?>" title="<?php echo $showdata['tour']; ?> iCalendar" class="gigpress-ical">iCal</a>
 	<?php endif; ?>	
 
 	<?php if($venue) : ?>
-		<a href="<?php echo GIGPRESS_RSS; ?>&amp;venue=<?php echo $showdata['venue_id']; ?>" title="<?php echo $showdata['venue']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;venue=' . $showdata['venue_id']; ?>" title="<?php echo $showdata['venue']; ?> iCalendar" class="gigpress-ical">iCal</a>
+		<a href="<?php echo GIGPRESS_RSS; ?>&amp;venue=<?php echo $showdata['venue_id']; ?>" title="<?php echo $showdata['venue_plain']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;venue=' . $showdata['venue_id']; ?>" title="<?php echo $showdata['venue']; ?> iCalendar" class="gigpress-ical">iCal</a>
 	<?php endif; ?>	
 					
 	</p>


### PR DESCRIPTION
Sidebar footers for tours & venues were using $showdata['venue'] &
$showdata['tour'] for the title but those return full url's and break
the links and we only needed the text.
The artist footer already reflects that (as it is most widely used) so
no change there.
