### PR TITLE
Forgot to include the fix for the iCal link which is the same as the RSS links.

### DIFF
--- a/gigpress/templates/sidebar-list-footer.php
+++ b/gigpress/templates/sidebar-list-footer.php
@@ -29,11 +29,11 @@ if($show_feeds) : ?>
 	<?php endif; ?>	
 		
 	<?php if($tour) : ?>
-		<a href="<?php echo GIGPRESS_RSS; ?>&amp;tour=<?php echo $showdata['tour_id']; ?>" title="<?php echo $showdata['tour_plain']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;tour=' . $showdata['tour_id']; ?>" title="<?php echo $showdata['tour']; ?> iCalendar" class="gigpress-ical">iCal</a>
+		<a href="<?php echo GIGPRESS_RSS; ?>&amp;tour=<?php echo $showdata['tour_id']; ?>" title="<?php echo $showdata['tour_plain']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;tour=' . $showdata['tour_id']; ?>" title="<?php echo $showdata['tour_plain']; ?> iCalendar" class="gigpress-ical">iCal</a>
 	<?php endif; ?>	
 
 	<?php if($venue) : ?>
-		<a href="<?php echo GIGPRESS_RSS; ?>&amp;venue=<?php echo $showdata['venue_id']; ?>" title="<?php echo $showdata['venue_plain']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;venue=' . $showdata['venue_id']; ?>" title="<?php echo $showdata['venue']; ?> iCalendar" class="gigpress-ical">iCal</a>
+		<a href="<?php echo GIGPRESS_RSS; ?>&amp;venue=<?php echo $showdata['venue_id']; ?>" title="<?php echo $showdata['venue_plain']; ?> RSS" class="gigpress-rss">RSS</a> | <a href="<?php echo GIGPRESS_WEBCAL . '&amp;venue=' . $showdata['venue_id']; ?>" title="<?php echo $showdata['venue_plain']; ?> iCalendar" class="gigpress-ical">iCal</a>
 	<?php endif; ?>	
 					
 	</p>


### PR DESCRIPTION
Forgot to include the title tag changes for the iCal links as we did
for the RSS link fix. (SORRY!)
Updated where we were getting $showdata['tour'] and $showdata['venue']
for the title tags to reflect the '%_plain' versions as we only want the
title text and not a URL.

Sorry for the duplicate pull request Derek!
