### PR TITLE
fix escaping of double quote markup in legacy up_json_encode function

### DIFF
--- a/trunk/lib/upgrade.php
+++ b/trunk/lib/upgrade.php
@@ -842,7 +842,7 @@ if (!defined("JSON_UNESCAPED_SLASHES")) {
              "<"  => $options & JSON_HEX_TAG  ? "\\u003C" : "<",
              ">"  => $options & JSON_HEX_TAG  ? "\\u003E" : ">",
              "'"  => $options & JSON_HEX_APOS ? "\\u0027" : "'",
-             "\"" => $options & JSON_HEX_QUOT ? "\\u0022" : "\"",
+              '"' => $options & JSON_HEX_QUOT ? "\\u0022" : '\"',
              "&"  => $options & JSON_HEX_AMP  ? "\\u0026" : "&",
          );
          $var = strtr($var, $rewrite);


### PR DESCRIPTION
the old function was not matching double quote characters and thus did not escape them in the resulting json

if this code came from an external source that source should be notified that their solution needs this update.
