### PR TITLE
JSON-LD can contain offers without prices

### DIFF
--- a/trunk/output/gigpress_shows.php
+++ b/trunk/output/gigpress_shows.php
@@ -467,19 +467,18 @@ function gigpress_json_ld($showdata)
 
 	// Merge venue into show
 	$show_markup['location'] = $location_markup;
-	
-	// Create offer (if price exists)
-	if(!empty($showdata['price']))
-	{
-		$offer_markup = array("@type" => "Offer");
-		
-		// Add offer attributes
-		if(!empty($showdata['price'])) { $offer_markup['price'] = $showdata['price']; }
-		if(!empty($showdata['ticket_url'])) { $offer_markup['url'] = $showdata['ticket_url']; }
-		if(!empty($showdata['ticket_phone'])) { $offer_markup['seller'] = array("@type" => "Organization", "telephone" => $showdata['ticket_phone']); }
-		if(!empty($showdata['status']) && $showdata['status'] == "soldout") { $offer_markup['availability'] = "SoldOut"; }
-		
-		// Merge offer into show
+
+	// Create offer
+	$offer_markup = array("@type" => "Offer");
+
+	// Add offer attributes
+	if(!empty($showdata['price'])) { $offer_markup['price'] = $showdata['price']; }
+	if(!empty($showdata['ticket_url'])) { $offer_markup['url'] = $showdata['ticket_url']; }
+	if(!empty($showdata['ticket_phone'])) { $offer_markup['seller'] = array("@type" => "Organization", "telephone" => $showdata['ticket_phone']); }
+	if(!empty($showdata['status']) && $showdata['status'] == "soldout") { $offer_markup['availability'] = "SoldOut"; }
+
+	// Merge offer into show (if any fields were added)
+	if(count($offer_markup) > 1) {
 		$show_markup['offers'] = $offer_markup;
 	}
 	


### PR DESCRIPTION
Removes the requirement that a price be included to include the offer url or other offer information in the JSON-LD markup.
This will allow users to include offer urls in their markup even when a price is not known.
