### PR TITLE
 Add support for single shows in sidebar widget

### DIFF
--- a/trunk/output/gigpress_sidebar.php
+++ b/trunk/output/gigpress_sidebar.php
@@ -294,12 +294,16 @@ function gigpress_sidebar($filter = null) {
 					// Close the previous tour if needed
 					if($show_tours && $current_tour && $showdata['tour'] != $current_tour) {
 						include gigpress_template('sidebar-tour-end');					
+					} else if(! $current_tour){
+						include gigpress_template('sidebar-single-end');	
 					}
 					
 					// Open the current tour if needed
 					if($show_tours && $showdata['tour'] && $showdata['tour'] != $current_tour && !$tour) {
 						$current_tour = $showdata['tour'];
 						include gigpress_template('sidebar-tour-heading');
+					} else if(! $current_tour){
+						include gigpress_template('sidebar-single-heading');	
 					}
 					
 					// Zero-out $current_tour
@@ -317,6 +321,8 @@ function gigpress_sidebar($filter = null) {
 				// Close the current tour if needed
 				if($show_tours && $current_tour) {
 					include gigpress_template('sidebar-tour-end');					
+				} else if(! $current_tour){
+					include gigpress_template('sidebar-single-end');	
 				}
 				
 				// Close the list
@@ -359,6 +365,8 @@ function gigpress_sidebar($filter = null) {
 				// Close the previous tour if needed
 				if($show_tours && $current_tour && $showdata['tour'] != $current_tour && !$tour) {
 					include gigpress_template('sidebar-tour-end');						
+				} else if(! $current_tour && ($i > 0)){
+					include gigpress_template('sidebar-single-end');	
 				}
 				
 				// Open the current tour if needed
@@ -367,7 +375,10 @@ function gigpress_sidebar($filter = null) {
 					include gigpress_template('sidebar-tour-heading');
 				}
 				
-				if(!$showdata['tour']) $current_tour = '';
+				if(!$showdata['tour']) {
+					$current_tour = '';
+					include gigpress_template('sidebar-single-heading');
+				}
 				
 				// Prepare the class
 				$class = ($i % 2) ? 'gigpress-alt ' : ''; $i++;
@@ -380,6 +391,8 @@ function gigpress_sidebar($filter = null) {
 			// Close the current tour if needed
 			if($show_tours && $current_tour && !$tour) {
 				include gigpress_template('sidebar-tour-end');						
+			} else if(! $current_tour){
+				include gigpress_template('sidebar-single-end');	
 			}
 			
 			// Close the list


### PR DESCRIPTION
Adds support for single shows (those that are not part of a tour) in the sidebar widget so that single shows and a collection of shows (tour) can be themed independently. Should also be implemented in gigpress_shows.php in some form.

I have not included new or updated template files.