### PR TITLE
Replace `get_currentuserinfo()` with `wp_get_current_user()`

### DIFF
--- a/admin/shows.php
+++ b/admin/shows.php
@@ -30,7 +30,7 @@ function gigpress_admin_shows() {
 	$pagination_args = array();
 
 	global $current_user;
-	get_currentuserinfo();
+	wp_get_current_user();
 	
 	if(isset($_GET['scope']))
 	{


### PR DESCRIPTION
Fixes the following message:

**Notice**: get_currentuserinfo is **deprecated** since version 4.5! Use wp_get_current_user() instead. in **/wp-includes/functions.php** on line **3657**