### PR TITLE
adding a filter on post type for related posts

### DIFF
--- a/admin/new.php
+++ b/admin/new.php
@@ -3,7 +3,7 @@
 function gigpress_add() {
 
 	global $wpdb, $wp_locale;
-		
+
 	if(isset($_POST['gpaction']) && $_POST['gpaction'] == "add") {
 		// This is for when we've just POST-ed a new show ...
 		require_once('handlers.php');
@@ -16,52 +16,52 @@ function gigpress_add() {
 	}
 
 	$gpo = get_option('gigpress_settings');
-		
+
 	// If they're done with the welcome message, kill it
 	if(isset($_GET['gpaction']) && $_GET['gpaction'] == "killwelcome") {
 		$gpo['welcome'] = "no";
 		update_option('gigpress_settings', $gpo);
 		$gpo = get_option('gigpress_settings');
 	}
-	
+
 	// If the welcome message is to be displayed, then do so
 	if($gpo['welcome'] == "yes") { ?>
-	
+
 		<div id="message" class="updated">
 			<p>
 				<?php _e("<strong>Welcome to GigPress!</strong> Get started by adding your first show below. To display your shows, simply add the", "gigpress"); ?> [gigpress_shows] <?php _e("shortcode to any page or post.", "gigpress"); ?>
 				<?php _e("Questions?  Please check out the", "gigpress"); ?> <a href="http://gigpress.com/docs"><?php _e("documentation", "gigpress"); ?></a> <?php _e("and", "gigpress"); ?> <a href="http://gigpress.com/faq"><?php _e("FAQ", "gigpress"); ?></a> <?php _e("on the GigPress website. Enjoy!", "gigpress"); ?> <small>(<a href="<?php echo admin_url('admin.php?page=gigpress&amp;gpaction=killwelcome'); ?>"><?php _e("Don't show this again", "gigpress"); ?>.</a>)</small>
 			</p>
 		</div>
-		
+
 	<?php } ?>
-	
+
 	<div class="wrap gigpress">
-	
+
 	<?php
-		
+
 		// Setup months
-		$gp_months = array('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12');		
-		
+		$gp_months = array('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12');
+
 		// Sanitize the show_id if we're editing or fixing errors
 		$show_id = (isset($_REQUEST['show_id'])) ? $wpdb->prepare('%d', $_REQUEST['show_id']) : '';
-	
+
 		// If the handler returned an array ($result), it means there were errors.
 		// This takes precedence over any other conditionals below.
-		
+
 		if(isset($result)) {
-		
+
 			$mm = sprintf("%02d", $_POST['gp_mm']);
 			$dd = sprintf("%02d", $_POST['gp_dd']);
 			$yy = sprintf("%02d", $_POST['gp_yy']);
-			
+
 			$hh = sprintf("%02d", $_POST['gp_hh']);
 			$min = sprintf("%02d", $_POST['gp_min']);
-				
+
 			$exp_mm = sprintf("%02d", $_POST['exp_mm']);
 			$exp_dd = sprintf("%02d", $_POST['exp_dd']);
 			$exp_yy = sprintf("%02d", $_POST['exp_yy']);
-			
+
 			$show_multi = (isset($_POST['show_multi']) && !empty($_POST['show_multi'])) ? 1 : FALSE;
 			$show_artist_id = absint($_POST['show_artist_id']);
 			$show_venue_id = absint($_POST['show_venue_id']);
@@ -70,7 +70,7 @@ function gigpress_add() {
 			$new_venue_name = gigpress_db_out(gigpress_db_in($_POST['venue_name']));
 			$venue_address = gigpress_db_out(gigpress_db_in($_POST['venue_address']));
 			$new_venue_city = gigpress_db_out(gigpress_db_in($_POST['venue_city']));
-			$venue_state = gigpress_db_out(gigpress_db_in($_POST['venue_state']));		
+			$venue_state = gigpress_db_out(gigpress_db_in($_POST['venue_state']));
 			$venue_postal_code = gigpress_db_out(gigpress_db_in($_POST['venue_postal_code']));
 			$venue_country = gigpress_db_out(gigpress_db_in($_POST['venue_country']));
 			$venue_url = gigpress_db_out(gigpress_db_in($_POST['venue_url']));
@@ -87,41 +87,41 @@ function gigpress_add() {
 			$show_related_title = gigpress_db_out(gigpress_db_in($_POST['show_related_title']));
 			$show_related_date = gigpress_db_in(gigpress_db_in($_POST['show_related_date']));
 			$show_status = gigpress_db_in($_POST['show_status']);
-			
+
 			$have_data = TRUE;
-		
+
 		} else if (isset($_GET['gpaction']) && ($_GET['gpaction'] == "edit" || $_GET['gpaction'] == "copy")) {
-	
+
 			// We're about to edit an existing show ...
 			// Load the previous show info into the edit form, and so forth
-			
+
 			$show_edit = $wpdb->get_results("
 			SELECT * from ". GIGPRESS_SHOWS ." WHERE show_id = ". $show_id ." LIMIT 1
 			");
 				if($show_edit) {
 					// We got the goods from the DB
 					foreach($show_edit as $show) {
-						
+
 						$show_date = explode('-', $show->show_date);
 							$mm = $show_date[1];
 							$dd = $show_date[2];
 							$yy = $show_date[0];
-						
+
 						$show_time = explode(':', $show->show_time);
 							$hh = $show_time[0];
 							$min = $show_time[1];
 							$ss = $show_time[2];
-							
+
 							if($ss == "01") {
 								$hh = "na";
 								$min = "na";
 							}
-							
+
 						$show_expire = explode('-', $show->show_expire);
 							$exp_mm = $show_expire[1];
 							$exp_dd = $show_expire[2];
 							$exp_yy = $show_expire[0];
-						
+
 						$show_multi = $show->show_multi;
 						$show_artist_id = $show->show_artist_id;
 						$show_venue_id = $show->show_venue_id;
@@ -133,46 +133,46 @@ function gigpress_add() {
 						$show_external_url = gigpress_db_out($show->show_external_url);
 						$show_tour_id = $show->show_tour_id;
 						$show_related = $show->show_related;
-						$show_related_title = $gpo['default_title'];	
+						$show_related_title = $gpo['default_title'];
 						$show_related_date = $gpo['related_date'];
-						$show_status = $show->show_status;			
+						$show_status = $show->show_status;
 					}
-					
+
 					$have_data = TRUE;
-					
+
 				} else {
-				
+
 					$have_data == FALSE;
 					$load_error = '<div id="message" class="error fade"><p>' . __("Sorry, but we had trouble loading that show for editing.", "gigpress") . '</div>';
-				
+
 				}
 		}
-		
+
 		if(!isset($have_data)) {
-	
+
 			// We're adding a new show, so get the defaults
-			
+
 			$show_date = explode('-', $gpo['default_date']);
 				$mm = $show_date[1];
 				$dd = $show_date[2];
 				$yy = $show_date[0];
-			
+
 			$show_time = explode(':', $gpo['default_time']);
 				$hh = $show_time[0];
 				$min = $show_time[1];
 				$ss = $show_time[2];
-				
+
 				if($ss == "01") {
 					$hh = "na";
 					$min = "na";
 				}
-				
+
 			$show_expire = explode('-', $gpo['default_date']);
 				$exp_mm = $show_expire[1];
 				$exp_dd = $show_expire[2];
 				$exp_yy = $show_expire[0];
-			
-			$show_multi = FALSE;	
+
+			$show_multi = FALSE;
 			$show_artist_id = (isset($gpo['default_artist'])) ? $gpo['default_artist'] : '';
 			$show_venue_id = (isset($gpo['default_venue'])) ? $gpo['default_venue'] : '';
 			$show_ages = (isset($gpo['default_ages'])) ? $gpo['default_ages'] : '';
@@ -181,36 +181,36 @@ function gigpress_add() {
 			$show_related_title = $gpo['default_title'];
 			$show_related_date = $gpo['related_date'];
 		}
-			
+
 		// We're editing a show
 		if(isset($_GET['gpaction']) && $_GET['gpaction'] == "edit" || (isset($result['editing']))) { ?>
-		
+
 			<h1><?php _e("Edit this show", "gigpress"); ?></h1>
-		
+
 			<form method="post" action="<?php echo admin_url('admin.php?page=gigpress'); ?>">
 				<?php wp_nonce_field('gigpress-action') ?>
 				<input type="hidden" name="gpaction" value="update" />
 				<input type="hidden" name="show_id" value="<?php echo $show_id; ?>" />
-		
+
 		<?php } else { // We're adding a new show ?>
-		
+
 			<h1><?php _e("Add a show", "gigpress"); ?></h1>
-			
+
 			<?php if(isset($load_error)) echo $load_error; ?>
-					
+
 			<form method="post" action="<?php echo admin_url('admin.php?page=gigpress'); ?>">
 				<?php wp_nonce_field('gigpress-action') ?>
 				<input type="hidden" name="gpaction" value="add" />
 				<input type="hidden" name="show_status" value="active" />
-				
+
 		<?php } ?>
-			
+
 			<table class="form-table gp-table" cellspacing="0">
 			<tbody>
 			  <tr>
 				<th scope="row"><label for="gp_mm"><?php _e("Date", "gigpress") ?>:<span class="gp-required">*</span></label></th>
 					<td>
-					<?php if(isset($result['show_date'])) echo('<span class="gigpress-error">'); ?>				
+					<?php if(isset($result['show_date'])) echo('<span class="gigpress-error">'); ?>
 					<select name="gp_mm" id="gp_mm">
 					<?php foreach($gp_months as $month) : ?>
 						<option value="<?php echo $month; ?>"<?php if($mm == $month) : ?> selected="selected"<?php endif; ?>>
@@ -226,7 +226,7 @@ function gigpress_add() {
 					  	echo('>' . $i . '</option>');
 					  	} ?>
 					  </select>
-					  
+
 					  <select name="gp_yy" id="gp_yy">
 					  	<?php for($i = 1900; $i <= 2050; $i++) {
 					  	echo('<option value="' . $i . '"');
@@ -235,9 +235,9 @@ function gigpress_add() {
 					  	} ?>
 					</select>
 					<?php if(isset($result['show_date'])) echo('</span>'); ?>
-				
-					&nbsp; <?php _e("at", "gigpress"); ?> &nbsp; 
-					
+
+					&nbsp; <?php _e("at", "gigpress"); ?> &nbsp;
+
 					<?php if(!empty($gpo['alternate_clock'])) { ?>
 					<select name="gp_hh" id="gp_hh" class="twentyfour">
 						<option value="na"<?php if($hh == "na") echo(' selected="selected"'); ?>>--</option>
@@ -332,7 +332,7 @@ function gigpress_add() {
 							</option>
 						<?php endforeach; ?>
 						</select>
-						
+
 						  <select name="exp_dd" id="exp_dd">
 						  	<?php for($i = 1; $i <= 31; $i++) {
 						  	$i = ($i < 10) ? '0' . $i : $i;
@@ -341,7 +341,7 @@ function gigpress_add() {
 						  	echo('>' . $i . '</option>');
 						  	} ?>
 						  </select>
-						  
+
 						  <select name="exp_yy" id="exp_yy">
 						  	<?php for($i = 1900; $i <= 2050; $i++) {
 						  	echo('<option value="' . $i . '"');
@@ -375,7 +375,7 @@ function gigpress_add() {
 					</td>
 				  </tr>
 				 </tbody>
-				 
+
 				<tbody id="show_artist_id_new" class="gigpress-addition<?php if(!isset($show_artist_id) || (isset($show_artist_id) && $show_artist_id != 'new') && !isset($no_artists)) echo(' gigpress-inactive'); ?>">
 				<tr>
 					<th scope="row"><label for="artist_name"><?php _e("Artist name", "gigpress"); ?>:<span class="gp-required">*</span></label></th>
@@ -386,9 +386,9 @@ function gigpress_add() {
 					<td>
 						<input name="artist_url" id="artist_url" type="text" size="48" value="<?php if(isset($artist_url)) echo $artist_url; ?>" />
 					</td>
-				</tr>				
+				</tr>
 				</tbody>
-				
+
 				<tbody>
 				<tr>
 					<th scope="row"><label for="show_venue_id"><?php _e("Venue", "gigpress") ?>:<span class="gp-required">*</span></label></th>
@@ -416,13 +416,13 @@ function gigpress_add() {
 					</td>
 				  </tr>
 				</tbody>
-				
+
 				<tbody id="show_venue_id_new" class="gigpress-addition<?php if(!isset($show_venue_id) || (isset($show_venue_id) && $show_venue_id != 'new')) echo(' gigpress-inactive'); ?>">
 				  <tr>
 					<th scope="row"><label for="venue_name"><?php _e("Venue name", "gigpress") ?>:<span class="gp-required">*</span></label>
 					</th>
 					<td><input type="text" size="48" name="venue_name" id="venue_name" value="<?php if(isset($new_venue_name)) echo $new_venue_name; ?>"<?php if(isset($result['venue_name'])) echo(' class="gigpress-error"'); ?> /></td>
-				  </tr>	
+				  </tr>
 				<tr>
 					<th scope="row"><label for="venue_address"><?php _e("Venue address", "gigpress") ?>:</label></th>
 					<td><input type="text" size="48" name="venue_address" id="venue_address" value="<?php if(isset($venue_address)) echo $venue_address; ?>" /></td>
@@ -430,7 +430,7 @@ function gigpress_add() {
 				<tr>
 					<th scope="row"><label for="venue_city"><?php _e("Venue city", "gigpress") ?>:<span class="gp-required">*</span></label></th>
 					<td><input type="text" size="48" name="venue_city" id="venue_city" value="<?php if(isset($new_venue_city)) echo $new_venue_city; ?>"<?php if(isset($result['venue_city'])) echo(' class="gigpress-error"'); ?> class="required" /></td>
-				</tr>			  		
+				</tr>
 				<tr>
 					<th scope="row"><label for="venue_state"><?php _e("Venue state/province", "gigpress") ?>:</label></th>
 					<td><input type="text" size="48" name="venue_state" id="venue_state" value="<?php if(isset($venue_state)) echo $venue_state; ?>" /></td>
@@ -438,7 +438,7 @@ function gigpress_add() {
 				<tr>
 					<th scope="row"><label for="venue_postal_code"><?php _e("Venue postal code", "gigpress") ?>:</label></th>
 					<td><input type="text" size="48" name="venue_postal_code" id="venue_postal_code" value="<?php if(isset($venue_postal_code)) echo $venue_postal_code; ?>" /></td>
-				  </tr>				  				  
+				  </tr>
 				 <tr>
 					<th scope="row"><label for="venue_country"><?php _e("Venue country", "gigpress") ?>:</label></th>
 					<td>
@@ -457,7 +457,7 @@ function gigpress_add() {
 						</select>
 					</td>
 				  </tr>
-				  			  
+
 				  <tr>
 					<th scope="row"><label for="venue_url"><?php _e("Venue website", "gigpress") ?>:</label></th>
 					<td><input type="text" size="48" name="venue_url" id="venue_url" value="<?php if(isset($venue_url)) echo $venue_url; ?>" /></td>
@@ -465,9 +465,9 @@ function gigpress_add() {
 				  <tr>
 					<th scope="row"><label for="venue_phone"><?php _e("Venue phone", "gigpress") ?>:</label></th>
 					<td><input type="text" size="48" name="venue_phone" id="venue_phone" value="<?php if(isset($venue_phone)) echo $venue_phone; ?>" /></td>
-				  </tr>			  
+				  </tr>
 				</tbody>
-				
+
 				<tbody>
 				<?php if(isset($_GET['gpaction']) && $_GET['gpaction'] == 'edit' || isset($result['editing'])) { ?>
 				<tr>
@@ -479,7 +479,7 @@ function gigpress_add() {
 						</select>
 					</td>
 				</tr>
-				<?php } ?>			
+				<?php } ?>
 				  <tr>
 					<th scope="row"><label for="show_ages"><?php _e("Admittance", "gigpress") ?>:</label></th>
 					<td><select name="show_ages" id="show_ages">
@@ -491,7 +491,7 @@ function gigpress_add() {
 					  		$selected = (isset($show_ages) && $show_ages == $age) ? ' selected="selected"' : '';
 					  		echo('<option value="' . $age . '"' . $selected . '>' . $age . '</option>
 					  		');
-					  	}	
+					  	}
 					  ?>
 					  </select>
 					</td>
@@ -511,7 +511,7 @@ function gigpress_add() {
 				  <tr>
 					<th scope="row"><label for="show_external_url"><?php _e("External URL", "gigpress") ?>:</label></th>
 					<td><input type="text" size="48" name="show_external_url" id="show_external_url" value="<?php if(isset($show_external_url)) echo $show_external_url; ?>" /></td>
-				  </tr>				  
+				  </tr>
 				  <tr>
 					<th scope="row"><label for="show_notes"><?php _e("Notes", "gigpress") ?>:</label></th>
 					<td>
@@ -543,14 +543,14 @@ function gigpress_add() {
 					</td>
 				  </tr>
 			</tbody>
-			
+
 			<tbody id="show_tour_id_new" class="gigpress-addition<?php if(!isset($show_tour_id) || (isset($show_tour_id) && $show_tour_id != 'new')) echo(' gigpress-inactive'); ?>">
 				<tr>
 					<th scope="row"><label for="tour_name"><?php _e("Tour name", "gigpress"); ?>:</label></th>
 					<td><input type="text" size="48" name="tour_name" id="tour_name" value="<?php if(isset($new_tour_name)) echo $new_tour_name; ?>"<?php if(isset($result['tour_name'])) echo(' class="gigpress-error"'); ?> /></td>
 				</tr>
-			</tbody>	  
-			
+			</tbody>
+
 			<tbody>
 			<tr>
 					<th scope="row"><label for="show_related"><?php _e("Related post", "gigpress") ?>:</label></th>
@@ -560,15 +560,23 @@ function gigpress_add() {
 							<option value="0">------------------</option>
 					  		<option value="new"<?php if( ( (isset($show_related) && $show_related !== "0") || (!isset($show_related) ) && isset($gpo['autocreate_post']) && $gpo['autocreate_post'] == "1") || (isset($show_related) && $show_related == 'new') ) echo(' selected="selected"'); ?>><?php _e("Add a new post", "gigpress") ?></option>
 							<option value="0">------------------</option>
-							
-					  	<?php 
-					  	$entries = $wpdb->get_results("SELECT p.ID, p.post_title FROM " . $wpdb->prefix . "posts p WHERE (p.post_status = 'publish' OR p.post_status = 'future') AND p.post_type = 'post' ORDER BY p.post_date DESC LIMIT 500", ARRAY_A);
-					  	if($entries != FALSE) {				  	
+
+					  	<?php
+					  	$related_posts_sql = "SELECT p.ID, p.post_title FROM " . $wpdb->prefix . "posts p WHERE (p.post_status = 'publish' OR p.post_status = 'future')";
+					  	$related_post_types = apply_filters( 'gigpress_related_post_types', array( 'post' ) );
+					  	if ( ! empty( $related_post_types ) ) {
+					  		 $related_posts_sql .= "AND p.post_type IN( '" . implode( "','", $related_post_types ) . "' )";
+					  	}
+
+					  	$related_posts_sql .= " ORDER BY p.post_date DESC LIMIT 500";
+
+					  	$entries = $wpdb->get_results($related_posts_sql, ARRAY_A);
+					  	if($entries != FALSE) {
 							foreach($entries as $entry) { ?>
 								<option value="<?php echo $entry['ID']; ?>"<?php if(isset($show_related) && $entry['ID'] == $show_related) { echo(' selected="selected"'); $found_related = TRUE; } ?>><?php echo gigpress_db_out($entry['post_title']); ?></option>
 						<?php }
 						} ?>
-						
+
 						<?php if(isset($show_related) && !isset($found_related)) {
 							$old_related = $wpdb->get_results("SELECT ID, post_title FROM " . $wpdb->prefix . "posts WHERE ID = ".$wpdb->prepare('%d', $show_related)." LIMIT 1", ARRAY_A);
 							if($old_related != FALSE) {
@@ -581,33 +589,33 @@ function gigpress_add() {
 					</td>
 				  </tr>
 				 </tbody>
-				 				 
+
 				<tbody id="show_related_new" class="gigpress-addition<?php if( (isset($show_related) && $show_related != 'new') || (empty($show_related) && empty($gpo['autocreate_post'])) ) echo(' gigpress-inactive'); ?>">
 				<tr>
 					<th scope="row"><label for="show_related_title"><?php _e("Related post title", "gigpress"); ?>:</label></th>
 					<td><input type="text" size="48" name="show_related_title" id="show_related_title" value="<?php if(isset($show_related_title)) echo $show_related_title; ?>" /><br />
 					<span class="description"><?php _e("Available placeholders:", "gigpress"); ?> <code>%date%</code>, <code>%long_date%</code>, <code>%artist%</code>, <code>%city%</code>, <code>%venue%</code>.</span><br />
-					<label><input type="radio" name="show_related_date" value="now"<?php if (isset($show_related_date) && $show_related_date == 'now') echo(' checked="checked"'); ?> /> <?php _e('Publish now', 'gigpress'); ?></label> &nbsp; 
+					<label><input type="radio" name="show_related_date" value="now"<?php if (isset($show_related_date) && $show_related_date == 'now') echo(' checked="checked"'); ?> /> <?php _e('Publish now', 'gigpress'); ?></label> &nbsp;
 					<label><input type="radio" name="show_related_date" value="show"<?php if (isset($show_related_date) && $show_related_date == 'show') echo(' checked="checked"'); ?> /> <?php _e('Publish on show date', 'gigpress'); ?></label>
 					</td>
 				</tr>
 			</tbody>
-			<tbody>  				 
+			<tbody>
 				<tr>
 					<td>&nbsp;</td>
 					<td>
 				<?php if(isset($_GET['gpaction']) && $_GET['gpaction'] == "edit" || isset($result['editing'])) { ?>
 					<span class="submit"><input type="submit" name="Submit" class="button-primary" value="<?php _e("Update show", "gigpress") ?>" /></span> <?php _e("or", "gigpress"); ?> <a href="<?php echo admin_url('admin.php?page=gigpress-shows'); ?>"><?php _e("cancel", "gigpress"); ?></a>
-				
+
 				<?php } else { ?>
-				
+
 					<span class="submit"><input type="submit" name="Submit" class="button-primary" value="<?php _e("Add show", "gigpress") ?>" /></span>
-				
+
 				<?php } ?>
 				</td>
 				</tr>
 				</tbody>
-			</table>		
+			</table>
 		</form>
 	</div>
 	<?php unset($result);

--- a/admin/new.php
+++ b/admin/new.php
@@ -563,6 +563,12 @@ function gigpress_add() {
 
 					  	<?php
 					  	$related_posts_sql = "SELECT p.ID, p.post_title FROM " . $wpdb->prefix . "posts p WHERE (p.post_status = 'publish' OR p.post_status = 'future')";
+					  	/**
+						 * Provides an opportunity to specify other post types as related posts
+						 *
+						 * @param array $related_post_types
+						 * @since 2.3.19
+						 */
 					  	$related_post_types = apply_filters( 'gigpress_related_post_types', array( 'post' ) );
 					  	if ( ! empty( $related_post_types ) ) {
 					  		 $related_posts_sql .= "AND p.post_type IN( '" . implode( "','", $related_post_types ) . "' )";

--- a/gigpress.php
+++ b/gigpress.php
@@ -3,12 +3,11 @@
 Plugin Name: GigPress
 Plugin URI: http://gigpress.com
 Description: GigPress is a live performance listing and management plugin built for musicians and performers.
-Version: 2.3.18
-Author: Derek Hogue
-Author URI: http://amphibian.info
+Version: 2.3.19
+Author: Modern Tribe
 Text Domain: gigpress
 
-Copyright 2007-2016 DEREK HOGUE
+Copyright 2007-2017 Modern Tribe
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -66,9 +65,9 @@ require('lib/countries.php');
 
 
 function gigpress_admin_menu() {
-	
+
 	global $gpo, $wp_version;
-	
+
 	$add = __("Add a show", "gigpress");
 	$shows = __("Shows", "gigpress");
 	$artists = __("Artists", "gigpress");
@@ -76,9 +75,9 @@ function gigpress_admin_menu() {
 	$tours = __("Tours", "gigpress");
 	$settings = __("Settings", "gigpress");
 	$export = __("Import/Export", "gigpress");
-	
+
 	$icon = ($wp_version >= 3.8) ? 'dashicons-calendar' : plugins_url('images/gigpress-icon-16.png', __FILE__);
-	
+
 	add_menu_page("GigPress &rsaquo; $add", "GigPress", $gpo['user_level'], 'gigpress', "gigpress_add", $icon);
 	// By setting the unique identifier of the submenu page to be __FILE__,
 	// we let it be the first page to load when the top-level menu item is clicked
@@ -89,11 +88,11 @@ function gigpress_admin_menu() {
 	add_submenu_page('gigpress', "GigPress &rsaquo; $tours", $tours, $gpo['user_level'], "gigpress-tours", "gigpress_tours");
 	add_submenu_page('gigpress', "GigPress &rsaquo; $settings", $settings, 'manage_options', "gigpress-settings", "gigpress_settings");
 	add_submenu_page('gigpress', "GigPress &rsaquo; $export", $export, $gpo['user_level'], "gigpress-import-export", "gigpress_import_export");
-	
+
 	if(GIGPRESS_DEBUG) {
 		require('admin/debug.php');
 		add_submenu_page('gigpress', "GigPress &rsaquo; Debug", 'Debug', 'manage_options', "gigpress-debug", "gigpress_debug");
-	}	
+	}
 
 }
 
@@ -118,7 +117,7 @@ function gigpress_admin_head()	{
 
 
 function gigpress_admin_footer() {
-	
+
 	return (__("You're using", "gigpress").' <a href="http://gigpress.com">GigPress '.GIGPRESS_VERSION.'</a>. '. __("Like it?", "gigpress") . ' <a href="http://gigpress.com/donate">' . __("Make a donation", "gigpress") . '</a>.');
 }
 
@@ -136,9 +135,9 @@ function gigpress_js() {
 
 
 function gigpress_head() {
-	
+
 	global $gpo;
-	
+
 	if(empty($gpo['disable_css']))
 	{
 		wp_enqueue_style('gigpress-css', plugins_url('css/gigpress.css', __FILE__));
@@ -151,7 +150,7 @@ function gigpress_head() {
 			wp_enqueue_style('gigpress-css-custom', get_template_directory_uri().'/gigpress.css', 'gigpress-css');
 		}
 	}
-	
+
 	if(!empty($gpo['rss_head'])){
 	// Adds auto-discovery of our RSS feed
 	echo('<link href="'.GIGPRESS_RSS.'" rel="alternate" type="application/rss+xml" title="'.$gpo['rss_title'].'" />
@@ -167,7 +166,7 @@ function gigpress_template($path) {
 	// 2) Parent theme directory
 	// 3) wp-content directory
 	// 4) Default template directory
-	
+
 	if(file_exists(get_stylesheet_directory() . '/gigpress-templates/' . $path . '.php')) {
 		$load = get_stylesheet_directory() . '/gigpress-templates/' . $path . '.php';
 	} elseif(file_exists(get_template_directory() . '/gigpress-templates/' . $path . '.php')) {
@@ -231,24 +230,24 @@ function gigpress_target($link = '') {
 	if(!empty($gpo['target_blank']) && strpos($link, $_SERVER['SERVER_NAME']) === FALSE) {
 		return ' target="_blank"';
 	}
-	
+
 }
 
 
 function gigpress_prepare($show, $scope = 'public') {
-	
+
 	// This function takes an array for one show ($show)
 	// and returns a new array containing the show data
 	// prepared for various outputs based on context and GigPress settings
-	
+
 	global $wpdb, $gp_countries, $gpo;
-	
+
 	$showdata = array();
-	
+
 	$showdata['address_plain'] = (!empty($show->venue_address)) ? wptexturize($show->venue_address) : '';
 	$showdata['address_url'] = (!empty($show->venue_address)) ? 'http://maps.google.com/maps?&amp;q='.
 		urlencode($show->venue_address).','.
-		urlencode($show->venue_city) : '';	
+		urlencode($show->venue_city) : '';
 	if(!empty($show->venue_state))
 	{
 		$showdata['address_url'] .= ','.urlencode($show->venue_state);
@@ -259,8 +258,8 @@ function gigpress_prepare($show, $scope = 'public') {
 	}
 	$showdata['address_url'] .= ','.urlencode($show->venue_country);
 	$showdata['address'] = (!empty($show->venue_address)) ? '<a href="' . $showdata['address_url'] . '" class="gigpress-address"' . gigpress_target($showdata['address_url']) . '>' . wptexturize($show->venue_address) . '</a>' : '';
-	$showdata['city'] = (!empty($show->show_related) && !empty($gpo['relatedlink_city']) && $scope == 'public') ? '<a href="' . gigpress_related_link($show->show_related, "url") . '">' . wptexturize($show->venue_city) . '</a>' : wptexturize($show->venue_city);	
-	$showdata['city_plain'] = wptexturize($show->venue_city);	
+	$showdata['city'] = (!empty($show->show_related) && !empty($gpo['relatedlink_city']) && $scope == 'public') ? '<a href="' . gigpress_related_link($show->show_related, "url") . '">' . wptexturize($show->venue_city) . '</a>' : wptexturize($show->venue_city);
+	$showdata['city_plain'] = wptexturize($show->venue_city);
 	$showdata['state'] = (!empty($show->venue_state)) ? $show->venue_state : '';
 	$showdata['postal_code'] = (!empty($show->venue_postal_code)) ? $show->venue_postal_code : '';
 	$showdata['country'] = (!empty($gpo['country_view'])) ? wptexturize($gp_countries[$show->venue_country]) : $show->venue_country;
@@ -268,7 +267,7 @@ function gigpress_prepare($show, $scope = 'public') {
 	$showdata['venue_id'] = $show->venue_id;
 	$showdata['venue_plain'] = wptexturize($show->venue_name);
 	$showdata['venue_phone'] = wptexturize($show->venue_phone);
-	$showdata['venue_url'] = (!empty($show->venue_url)) ? esc_url($show->venue_url) : '';	
+	$showdata['venue_url'] = (!empty($show->venue_url)) ? esc_url($show->venue_url) : '';
 
 	// Shield these fields when we're calling this function from the venues admin screen
 	if($scope != 'venue') {
@@ -295,18 +294,18 @@ function gigpress_prepare($show, $scope = 'public') {
 		$showdata['calendar_location_ical'] = str_replace(",", "\,", $showdata['calendar_location']);
 		$showdata['calendar_start'] = ($timeparts[2] == '01') ? str_replace('-', '', $show->show_date) : str_replace(array('-',':',' '), array('','','T'), gigpress_gmt($show->show_date . ' ' . $show->show_time)) . 'Z';
 		if($timeparts[2] == '01') {
-			$showdata['calendar_end'] = ($show->show_expire == $show->show_date) ? $showdata['calendar_start'] : date('Ymd', strtotime($show->show_expire . '+1 day'));	
+			$showdata['calendar_end'] = ($show->show_expire == $show->show_date) ? $showdata['calendar_start'] : date('Ymd', strtotime($show->show_expire . '+1 day'));
 		} else {
-			$showdata['calendar_end'] = ($show->show_expire == $show->show_date) ? $showdata['calendar_start'] : str_replace(array('-',':',' '), array('','','T'), gigpress_gmt($show->show_expire . ' ' . $show->show_time)) . 'Z';		
+			$showdata['calendar_end'] = ($show->show_expire == $show->show_date) ? $showdata['calendar_start'] : str_replace(array('-',':',' '), array('','','T'), gigpress_gmt($show->show_expire . ' ' . $show->show_time)) . 'Z';
 		}
 		$showdata['date'] = ($show->show_related && !empty($gpo['relatedlink_date']) && $scope == 'public') ? '<a href="' . gigpress_related_link($show->show_related, "url") . '">' . mysql2date($gpo['date_format'], $show->show_date) . '</a>' : mysql2date($gpo['date_format'], $show->show_date);
-		$showdata['date_long'] = mysql2date($gpo['date_format_long'], $show->show_date);		
-		$showdata['date_mysql'] = $show->show_date;		
+		$showdata['date_long'] = mysql2date($gpo['date_format_long'], $show->show_date);
+		$showdata['date_mysql'] = $show->show_date;
 		$showdata['end_date'] = ($show->show_date != $show->show_expire) ? mysql2date($gpo['date_format'], $show->show_expire) : '';
 		$showdata['end_date_long'] = ($show->show_date != $show->show_expire) ? mysql2date($gpo['date_format_long'], $show->show_expire) : '';
-		$showdata['end_date_mysql'] = $show->show_expire;		
-		$showdata['external_link'] = (!empty($show->show_external_url)) ? '<a href="'.esc_url($show->show_external_url).'"'.gigpress_target($show->show_external_url).'>'.$gpo['external_link_label'].'</a>' : '';		
-		$showdata['external_url'] = (!empty($show->show_external_url)) ? esc_url($show->show_external_url) : '';		
+		$showdata['end_date_mysql'] = $show->show_expire;
+		$showdata['external_link'] = (!empty($show->show_external_url)) ? '<a href="'.esc_url($show->show_external_url).'"'.gigpress_target($show->show_external_url).'>'.$gpo['external_link_label'].'</a>' : '';
+		$showdata['external_url'] = (!empty($show->show_external_url)) ? esc_url($show->show_external_url) : '';
 		$showdata['ical'] = '<a href="' . GIGPRESS_ICAL . '&amp;show_id=' . $show->show_id . '">' . __("Download iCal", "gigpress") . '</a>';
 		$showdata['id'] = $show->show_id;
 		$showdata['iso_date'] = $show->show_date."T".$show->show_time;
@@ -335,7 +334,7 @@ function gigpress_prepare($show, $scope = 'public') {
 		if($showdata['related_url']) { $showdata['permalink'] = $showdata['related_url']; }
 			elseif($gpo['shows_page']) { $showdata['permalink'] = esc_url($gpo['shows_page']); }
 			else { $showdata['permalink'] = get_bloginfo('url'); }
-		
+
 		// Google Calendar
 		$showdata['gcal'] = '<a href="http://www.google.com/calendar/event?action=TEMPLATE'
 			. '&amp;text=' . urlencode($showdata['calendar_summary'])
@@ -345,9 +344,9 @@ function gigpress_prepare($show, $scope = 'public') {
 			. '&amp;location=' . urlencode($showdata['calendar_location'])
 			. '&amp;details=' . urlencode($showdata['calendar_details'])
 			. '&amp;trp=true;'
-			. '"' . gigpress_target() . '>' . __("Add to Google Calendar", "gigpress") . '</a>';	
+			. '"' . gigpress_target() . '>' . __("Add to Google Calendar", "gigpress") . '</a>';
 	}
-		
+
 	return $showdata;
 }
 
@@ -355,9 +354,9 @@ function gigpress_prepare($show, $scope = 'public') {
 function gigpress_related_link($postid, $format) {
 
 	if($postid == 0) return;
-	
+
 	global $gpo;
-	
+
 	switch($format) {
 		case 'url':
 			$link = get_permalink($postid);
@@ -372,7 +371,7 @@ function gigpress_related_link($postid, $format) {
 			$output = '<a href="' . $link . '">' . $gpo['related'] . '</a>';
 			break;
 	}
-		
+
 	return $output;
 }
 
@@ -380,11 +379,11 @@ function gigpress_related_link($postid, $format) {
 function gigpress_exclude_shows($query) {
 	// Excludes the Related Post category from normal listings
 	global $wp_query, $gpo;
-	
+
 	$categories = array($gpo['related_category']);
-	
-	if( is_object($wp_query) && !is_category() && !is_single() && !is_tag() && !is_admin() && !is_search() ) { 
-		$wp_query->set('category__not_in', $categories); 
+
+	if( is_object($wp_query) && !is_category() && !is_single() && !is_tag() && !is_admin() && !is_search() ) {
+		$wp_query->set('category__not_in', $categories);
 	}
 }
 
@@ -402,15 +401,15 @@ function gigpress_remove_related($postID) {
 	global $wpdb;
 	$cleanup = $wpdb->update(GIGPRESS_SHOWS, array('show_related' => 0), array('show_related' => $postID), array('%d', '%d'));
 	return $postID;
-	
+
 }
 
 
 function add_gigpress_feeds() {
-	
+
 	// Tell WP about the shows feed
 	add_feed('gigpress','gigpress_feed');
-	
+
 	// Add the iCal export as a feed as well, even though it's not technically a feed
 	add_feed('gigpress-ical','gigpress_ical');
 
@@ -418,11 +417,11 @@ function add_gigpress_feeds() {
 
 
 function gigpress_admin_pagination($total_records, $records_per_page, $args) {
-	
+
 	$total_pages = ceil($total_records / $records_per_page);
 	$current_page = (isset($_GET['gp-page'])) ? $_GET['gp-page'] : 1;
 	$r = array();
-	
+
 	if($total_pages > 1) {
 		$r['output'] = '<div class="tablenav-pages">';
 		$page_links = paginate_links( array(
@@ -430,7 +429,7 @@ function gigpress_admin_pagination($total_records, $records_per_page, $args) {
 			'current' => $current_page,
 			'base' => 'admin.php?%_%',
 			'prev_text' => '&laquo;',
-			'next_text' => '&raquo;',					
+			'next_text' => '&raquo;',
 			'format' => 'gp-page=%#%',
 			'add_args' => $args
 		) );
@@ -442,7 +441,7 @@ function gigpress_admin_pagination($total_records, $records_per_page, $args) {
 		$page_links);
 		$r['output'] .= '</div>';
 		$r['offset'] = ($current_page - 1) * $records_per_page;
-		$r['records_per_page'] = $records_per_page;		
+		$r['records_per_page'] = $records_per_page;
 		return $r;
 	}
 }
@@ -476,26 +475,26 @@ function register_gigpress_settings() {
 
 function gigpress_favorites($actions) {
 	global $gpo;
-	$level = "level_" . $gpo['user_level']; 
+	$level = "level_" . $gpo['user_level'];
 	$actions['admin.php?page=gigpress'] = array('Add a show', $level);
     return $actions;
 }
 
 
 function custom_menu_order($menu_order) {
-	
+
 	if($current_position = array_search('gigpress', $menu_order))
 	{
 		// Add a new separator to the menu array
 		global $menu;
 		$menu[] = array('', 'read', 'separator-gp', '', 'wp-menu-separator');
-		
+
 		// Remove the current instance of GigPress
 		unset($menu_order[$current_position]);
-		
+
 		// Create a new array to hold the menu order
 		$new_menu_order = array();
-		
+
 		// Replicate the existing order,
 		// inserting GigPress and separator where desired
 		foreach($menu_order as $menu_item) {
@@ -503,15 +502,15 @@ function custom_menu_order($menu_order) {
 			if($menu_item == 'edit-comments.php')
 			{
 				$new_menu_order[] =  'separator-gp';
-				$new_menu_order[] = 'gigpress';		
+				$new_menu_order[] = 'gigpress';
 			}
 		}
 	}
 	else
 	{
-		$new_menu_order = $menu_order;		
+		$new_menu_order = $menu_order;
 	}
-	return $new_menu_order;		
+	return $new_menu_order;
 }
 
 
@@ -521,22 +520,22 @@ function add_upload_ext($mimes='') {
 }
 
 function gigpress_reorder_artists() {
-	
+
 	global $wpdb;
 	$wpdb->show_errors();
-	
+
 	$sql = "UPDATE " . GIGPRESS_ARTISTS . " SET artist_order = CASE artist_id ";
 	foreach($_REQUEST['artist'] as $order => $artist) {
 		$sql .= $wpdb->prepare("WHEN %d THEN %d ", $artist, $order);
 	}
 	$sql .= " END";
-	
+
 	$update_order = $wpdb->query($sql);
-	
+
 	if($update_order !== FALSE) {
 		_e("Artist order updated.", "gigpress");
 	}
-	
+
 	die();
 }
 
@@ -562,17 +561,17 @@ function gigpress_export() {
 	if(isset($_POST['tour_id']) && $_POST['tour_id'] != '-1') {
 		$further_where .= ' AND s.show_tour_id = ' . $wpdb->prepare('%d', $_POST['tour_id']) . ' ';
 	}
-	
+
 	$name = 'gigpress-export-' . date('Y-m-d') . '.csv';
-	
+
 	$fields = array(
 		"Date", "Time", "End date", "Artist", "Artist URL", "Venue", "Address", "City", "State", "Postal code", "Country", "Venue phone", "Venue URL", "Admittance", "Price", "Ticket URL", "Ticket phone", "External URL", "Notes", "Tour", "Status", "Related ID", "Related URL"
 	);
-	
+
 	$shows = $wpdb->get_results("
 		SELECT show_date, show_time, show_expire, artist_name, artist_url, venue_name, venue_address, venue_city, venue_state, venue_postal_code, venue_country, venue_phone, venue_url, show_ages, show_price, show_tix_url, show_tix_phone, show_external_url, show_notes, tour_name, show_status, show_related FROM ". GIGPRESS_VENUES ." as v, " . GIGPRESS_ARTISTS . " as a, " . GIGPRESS_SHOWS . " as s LEFT JOIN " . GIGPRESS_TOURS . " as t ON s.show_tour_id = t.tour_id WHERE show_status != 'deleted' AND s.show_artist_id = a.artist_id AND s.show_venue_id = v.venue_id" . $further_where . " ORDER BY show_date DESC,show_time DESC
 		", ARRAY_A);
-	
+
 	if($shows) {
 		$export_shows = array();
 		foreach ( $shows as $show ) {
@@ -581,13 +580,13 @@ function gigpress_export() {
 			$show['show_related_url'] = ( $show['show_related'] ) ? gigpress_related_link($show['show_related'], 'url') : '';
 			$export_shows[] = $show;
 		}
-	
+
 		$export = new parseCSV();
 		$export->output($name, stripslashes_deep($export_shows), $fields, ',');
 	} else {
 		echo('<p>' . __('Nothing to export.', 'gigpress') . '</p>');
 	}
-	
+
 }
 
 
@@ -610,7 +609,7 @@ function gigpress_save_settings()
 function fetch_gigpress_artists() {
 	global $wpdb;
 	$artists = $wpdb->get_results("
-		SELECT * FROM ". GIGPRESS_ARTISTS ." 
+		SELECT * FROM ". GIGPRESS_ARTISTS ."
 		ORDER BY artist_order ASC,artist_alpha ASC");
 	return ($artists !== FALSE) ? $artists : FALSE;
 }
@@ -619,8 +618,8 @@ function fetch_gigpress_artists() {
 function fetch_gigpress_tours() {
 	global $wpdb;
 	$tours = $wpdb->get_results("
-		SELECT * FROM ". GIGPRESS_TOURS ." 
-		WHERE tour_status = 'active' 
+		SELECT * FROM ". GIGPRESS_TOURS ."
+		WHERE tour_status = 'active'
 		ORDER BY tour_name ASC");
 	return ($tours !== FALSE) ? $tours : FALSE;
 }
@@ -629,7 +628,7 @@ function fetch_gigpress_tours() {
 function fetch_gigpress_venues() {
 	global $wpdb;
 	$venues = $wpdb->get_results("
-		SELECT * FROM ". GIGPRESS_VENUES ." 
+		SELECT * FROM ". GIGPRESS_VENUES ."
 		ORDER BY venue_name ASC, venue_city ASC");
 	return ($venues !== FALSE) ? $venues : FALSE;
 }
@@ -640,7 +639,7 @@ register_uninstall_hook(__FILE__, 'gigpress_uninstall');
 
 add_action('init','add_gigpress_feeds');
 add_action('init','gigpress_intl');
-add_action('admin_init', 'register_gigpress_settings'); 
+add_action('admin_init', 'register_gigpress_settings');
 add_action('admin_menu', 'gigpress_admin_menu');
 add_action('admin_bar_menu', 'gigpress_toolbar', 999);
 add_action('delete_post', 'gigpress_remove_related');

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,10 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 
 == Changelog ==
 
+= 2.3.19 [2017-08-23] =
+
+* Tweak - Added filter 'gigpress_related_post_types' to allow more than just "post" for related posts [85214]
+
 = 2.3.18 [2017-06-28] =
 
 * Tweak - The Show Notes field can now render shortcodes (props to @cowboyofbottrop)


### PR DESCRIPTION
This is *not* ideal code. It is the minimal change to achieve our goals.

See: https://central.tri.be/issues/85214

Note: my editor auto-removed trailing whitespace, review with `?w=1` for simplification.


Example filter:
```
add_filter( 'gigpress_related_post_types', 'add_more_gigpress_related_post_types' );

function add_more_gigpress_related_post_types( $related_post_types ) {
	$related_post_types[] = 'page';

	return $related_post_types;
}
```