### PR TITLE
Removing duplicates in css

### DIFF
--- a/css/gigpress.css
+++ b/css/gigpress.css
@@ -149,9 +149,6 @@ strong.gigpress-cancelled, strong.gigpress-soldout {
 	text-transform: uppercase;
 	font-weight: bold;
 	padding: 1px;
-	color: #111;
-	background: #fffdeb;
-	border: 1px solid #EEE;
 	background: #111;
 	color: #FFF;
 	border: none;


### PR DESCRIPTION
3 attributes (background, color, border) are duplicated. This will be reported as an warning by csslint in the code editor in the next version of WordPress (4.9). Removed the superfluous entries.
Reported by @joneiseman here:
https://wordpress.org/support/topic/duplicate-property-in-css/