### PR TITLE
Fix/79184 json ld prices

### DIFF
--- a/output/gigpress_shows.php
+++ b/output/gigpress_shows.php
@@ -537,7 +537,8 @@ function gigpress_json_ld( $showdata ) {
 
 	// Add offer attributes
 	if ( ! empty( $showdata['price'] ) ) {
-		$offer_markup['price'] = $showdata['price'];
+		// Filter out symbols like '$' per http://schema.org/PriceSpecification
+		$offer_markup['price'] = preg_replace( '/[^0-9\.,]/', '', $showdata['price'] );
 	}
 	if ( ! empty( $showdata['ticket_url'] ) ) {
 		$offer_markup['url'] = $showdata['ticket_url'];
@@ -554,5 +555,14 @@ function gigpress_json_ld( $showdata ) {
 		$show_markup['offers'] = $offer_markup;
 	}
 
-	return $show_markup;
+	/**
+	 * Provides an opportunity to customize and alter the JSON LD output for
+	 * a specific show.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $show_markup
+	 * @param array $showdata
+	 */
+	return apply_filters( 'gigpress_show_json_ld_markup', $show_markup, $showdata );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,8 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 
 = 2.3.20 [TBD] =
 
-
+* Fix - Strip invalid characters from price field in JSON LD output (our thanks to dekruyff for highlighting this) [79184]
+* Tweak - Added new filter hook `gigpress_show_json_ld_markup` to make modifications to JSON LD output easier [79184]
 
 = 2.3.19 [2017-08-24] =
 


### PR DESCRIPTION
Symbols such as `$` should not be used within the JSON LD price field. This change strips those out and adds a filter so that other changes can easily be made.

Commas should also be removed, but I'm deliberately letting them through because A) the core issue related to symbols such as `$` B) we don't know how show authors intend commas to be interpreted C) this is a fast and easy fix.

:ticket: [♯79184](https://central.tri.be/issues/79184)