### PR TITLE
Strip donate link (404'd) from admin credit | #85602

### DIFF
--- a/gigpress.php
+++ b/gigpress.php
@@ -117,8 +117,12 @@ function gigpress_admin_head()	{
 
 
 function gigpress_admin_footer() {
-
-	return (__("You're using", "gigpress").' <a href="http://gigpress.com">GigPress '.GIGPRESS_VERSION.'</a>. '. __("Like it?", "gigpress") . ' <a href="http://gigpress.com/donate">' . __("Make a donation", "gigpress") . '</a>.');
+	return sprintf(
+		__( 'You&#146;re using %1$sGigPress %2$s%3$s.', 'gigpress' ),
+		'<a href="http://gigpress.com">',
+		GIGPRESS_VERSION,
+		'</a>'
+	);
 }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 
 = 2.3.20 [TBD] =
 
-
+* Tweak - Adjusted admin footer credit [85602]
 
 = 2.3.19 [2017-08-24] =
 


### PR DESCRIPTION
Donate link in the admin footer doesn't work (results in a 404). Stripping it (we could create a new donate link, but simply removing it is how we'll proceed, per Z).

:ticket: [♯85602](https://central.tri.be/issues/85602)