### PR TITLE
Use plain output (avoid HTML links) in JSON LD addressLocality field …

### DIFF
--- a/output/gigpress_shows.php
+++ b/output/gigpress_shows.php
@@ -515,7 +515,7 @@ function gigpress_json_ld( $showdata ) {
 	if ( ! empty( $showdata['address_plain'] ) ) {
 		$address_markup['streetAddress'] = $showdata['address_plain'];
 	}
-	$address_markup['addressLocality'] = $showdata['city'];
+	$address_markup['addressLocality'] = $showdata['city_plain'];
 	if ( ! empty( $showdata['state'] ) ) {
 		$address_markup['addressRegion'] = $showdata['state'];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 
 = 2.3.20 [TBD] =
 
-
+* Fix - Modified JSON LD output to remove HTML from the address locality field (our thanks to sinoq for flagging this problem) [101503]
 
 = 2.3.19 [2017-08-24] =
 


### PR DESCRIPTION
Avoid using HTML links within the _addressLocality_ field (as this invalidates the JSON LD feed).

:ticket: [♯101503](https://central.tri.be/issues/1015003)