### PR TITLE
⌗116319 Allow Constants to Be Newly Defined Without PHP Notices

### DIFF
--- a/gigpress.php
+++ b/gigpress.php
@@ -23,22 +23,56 @@ GNU General Public License for more details.
 global $wpdb;
 
 // Define useful constants
-define( 'GIGPRESS_SHOWS', $wpdb->prefix . 'gigpress_shows' );
-define( 'GIGPRESS_TOURS', $wpdb->prefix . 'gigpress_tours' );
-define( 'GIGPRESS_ARTISTS', $wpdb->prefix . 'gigpress_artists' );
-define( 'GIGPRESS_VENUES', $wpdb->prefix . 'gigpress_venues' );
-define( 'GIGPRESS_VERSION', '2.3.22' );
-define( 'GIGPRESS_DB_VERSION', '1.6' );
-define( 'GIGPRESS_RSS', get_bloginfo( 'url' ) . '/?feed=gigpress' );
-define( 'GIGPRESS_ICAL', get_bloginfo( 'url' ) . '/?feed=gigpress-ical' );
-define( 'GIGPRESS_WEBCAL', str_replace( 'http://', 'webcal://', GIGPRESS_ICAL ) );
-define( 'GIGPRESS_DEBUG', true);
+if ( ! defined( 'GIGPRESS_SHOWS' ) ) {
+	define( 'GIGPRESS_SHOWS', $wpdb->prefix . 'gigpress_shows' );
+}
+
+if ( ! defined( 'GIGPRESS_TOURS' ) ) {
+	define( 'GIGPRESS_TOURS', $wpdb->prefix . 'gigpress_tours' );
+}
+
+if ( ! defined( 'GIGPRESS_ARTISTS' ) ) {
+	define( 'GIGPRESS_ARTISTS', $wpdb->prefix . 'gigpress_artists' );
+}
+
+if ( ! defined( 'GIGPRESS_VENUES' ) ) {
+	define( 'GIGPRESS_VENUES', $wpdb->prefix . 'gigpress_venues' );
+}
+
+if ( ! defined( 'GIGPRESS_VERSION' ) ) {
+	define( 'GIGPRESS_VERSION', '2.3.22' );
+}
+
+if ( ! defined( 'GIGPRESS_DB_VERSION' ) ) {
+	define( 'GIGPRESS_DB_VERSION', '1.6' );
+}
+
+if ( ! defined( 'GIGPRESS_RSS' ) ) {
+	define( 'GIGPRESS_RSS', get_bloginfo( 'url' ) . '/?feed=gigpress' );
+}
+
+if ( ! defined( 'GIGPRESS_ICAL' ) ) {
+	define( 'GIGPRESS_ICAL', get_bloginfo( 'url' ) . '/?feed=gigpress-ical' );
+}
+
+if ( ! defined( 'GIGPRESS_WEBCAL' ) ) {
+	define( 'GIGPRESS_WEBCAL', str_replace( 'http://', 'webcal://', GIGPRESS_ICAL ) );
+}
+
+if ( ! defined( 'GIGPRESS_DEBUG' ) ) {
+	define( 'GIGPRESS_DEBUG', true);
+}
 
 require( 'admin/db.php' );
 
-define( 'GIGPRESS_URL', ( $gpo['shows_page'] ) ? esc_url( $gpo['shows_page'] ) : get_bloginfo( 'url' ) );
+if ( ! defined( 'GIGPRESS_URL' ) ) {
+	define( 'GIGPRESS_URL', ( $gpo['shows_page'] ) ? esc_url( $gpo['shows_page'] ) : get_bloginfo( 'url' ) );
+}
 
-define( 'GIGPRESS_NOW', gmdate( 'Y-m-d', ( time() + gigpress_timezone_offset() ) ) );
+if ( ! defined( 'GIGPRESS_NOW' ) ) {
+	define( 'GIGPRESS_NOW', gmdate( 'Y-m-d', ( time() + gigpress_timezone_offset() ) ) );
+}
+
 if ( empty( $gpo['default_date'] ) ) {
 	$gpo['default_date'] = GIGPRESS_NOW;
 	update_option( 'gigpress_settings', $gpo );
@@ -62,7 +96,6 @@ require( 'output/ical.php' );
 
 global $gp_countries;
 require( 'lib/countries.php' );
-
 
 function gigpress_admin_menu() {
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,8 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 
 = 2.3.22 TBD =
 
+* Fix - Allow GigPress constants to be overridden if new constants are defined in a callback to the `plugins_loaded` action hook. Thanks @thomasdebruin for submitting this fix! [116319]
+
 = 2.3.21 [2018-08-01] =
 
 * Fix - Add Privacy Policy guide for Gigpress [108457]


### PR DESCRIPTION
**Ticket:** [**⌗116319**](http://central.tri.be/issues/116319)

**Original PR:** https://github.com/moderntribe/gigpress/pull/36

Major props to @thomasdebruin for submitting these changes!

**Note:** Adding these checks is only half the battle. Since this is a plugin, if a user defines new constants from within another plugin or a mu-plugin, it'll work great.

But if they redefine the constants from within a theme's `functions.php` file, then the `gigpress.php` file's definitions will run first, triggering a PHP notice anyways once the theme's `functions.php` file is loaded later. So the theme user would have to wrap their definitions in a callback function attached to the `plugins_loaded` hook. Just noting that here.