### PR TITLE
[GP-3] Fixed 'Array and string offset access syntax with curly braces is deprecated' error in PHP 7.4

### DIFF
--- a/gigpress.php
+++ b/gigpress.php
@@ -616,7 +616,7 @@ function gigpress_export() {
 	if ( $shows) {
 		$export_shows = array();
 		foreach ( $shows as $show ) {
-			$show['show_time'] = ( $show['show_time']{7} == 1 ) ? '' : $show['show_time'];
+			$show['show_time'] = ( $show['show_time'][7] == 1 ) ? '' : $show['show_time'];
 			$show['show_expire'] = ( $show['show_date'] == $show['show_expire'] ) ? '' : $show['show_expire'];
 			$show['show_related_url'] = ( $show['show_related'] ) ? gigpress_related_link( $show['show_related'], 'url' ) : '';
 			$export_shows[] = $show;


### PR DESCRIPTION
[GP-3]

[GP-3]: https://moderntribe.atlassian.net/browse/GP-3