### PR TITLE
[GP-5] Update new.php

### DIFF
--- a/admin/new.php
+++ b/admin/new.php
@@ -578,13 +578,14 @@ function gigpress_add() {
 
 					  	$entries = $wpdb->get_results($related_posts_sql, ARRAY_A);
 
-						$entries = apply_filters( 'gigpress_related_post_entries', $entries );
 						/**
-						 * Provides an opportunity to specify in details what's available as related posts
+						 * Provides an opportunity to specify in details what's available as related posts.
 						 *
-						 * @param array $entries
 						 * @since 2.3.24
+						 *
+						 * @param array $entries List of entries.
 						 */
+						$entries = apply_filters( 'gigpress_related_post_entries', $entries );
 
 						if($entries != FALSE) {
 							foreach($entries as $entry) { ?>

--- a/admin/new.php
+++ b/admin/new.php
@@ -577,7 +577,16 @@ function gigpress_add() {
 					  	$related_posts_sql .= " ORDER BY p.post_date DESC LIMIT 500";
 
 					  	$entries = $wpdb->get_results($related_posts_sql, ARRAY_A);
-					  	if($entries != FALSE) {
+
+						$entries = apply_filters( 'gigpress_related_post_entries', $entries );
+						/**
+						 * Provides an opportunity to specify in details what's available as related posts
+						 *
+						 * @param array $entries
+						 * @since 2.3.24
+						 */
+
+						if($entries != FALSE) {
 							foreach($entries as $entry) { ?>
 								<option value="<?php echo $entry['ID']; ?>"<?php if(isset($show_related) && $entry['ID'] == $show_related) { echo(' selected="selected"'); $found_related = TRUE; } ?>><?php echo gigpress_db_out($entry['post_title']); ?></option>
 						<?php }


### PR DESCRIPTION
Add an opportunity to specify in details what's available as related posts.
I needed this because with wpml I got posts in 2 languages, but we only wanted to list the default language, therefore we need this filter. This is probably useful for other users.

[GP-5]

[GP-5]: https://moderntribe.atlassian.net/browse/GP-5